### PR TITLE
Add updates to Go releases

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # defaults file for teleirc
-default_irc_server: chat.freenode.net
+default_irc_server: irc.libera.chat
 default_irc_nickserv_service: NickServ
-default_version: v2.0.0-pre2
+default_version: v2.1.0

--- a/tasks/compile.yml
+++ b/tasks/compile.yml
@@ -16,7 +16,7 @@
 
 - name: build teleirc binary
   command:
-    cmd: go build cmd/teleirc.go
+    cmd: bash build_binary.sh
     chdir: "/tmp/teleirc/"
 
 - name: push teleirc binary to /usr/local/bin

--- a/templates/env
+++ b/templates/env
@@ -54,5 +54,4 @@ SHOW_LEAVE_MESSAGE=false
 #                                                                             #
 ###############################################################################
 
-USE_IMGUR_FOR_IMAGES=true
 IMGUR_CLIENT_ID={{ item.value.imgur_client_id }}

--- a/vars/example_vault.yml
+++ b/vars/example_vault.yml
@@ -1,7 +1,8 @@
 ---
 # encrypt this with Ansible Vault before committing!
 
-vault_default_imgur_client_id: "000000000000000"
+# Default TeleIRC imgur API token. It is heavily recommended to create your own.
+vault_default_imgur_client_id: "7d6b00b87043f58"
 
 vault_bots:
   my_example_bot:


### PR DESCRIPTION
This PR updates the default TeleIRC version to v2.1.0, and makes other subtle improvements to allow for a smooth v2.0.0 ansible transition. 