### PR TITLE
handlers: Run systemd daemon reload when unit file changes

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,7 @@
     name: "teleirc-{{ item.value.cn }}.service"
     state: restarted
   loop: "{{ bots|dict2items }}"
+
+- name: systemd daemon reload
+  ansible.builtin.systemd:
+    daemon_reload: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -19,6 +19,7 @@
     seuser: system_u
     setype: systemd_unit_file_t
   loop: "{{ bots|dict2items }}"
+  notify: systemd daemon reload
 
 - name: start/enable each TeleIRC systemd unit file
   service:


### PR DESCRIPTION
This will make sure that systemd picks up the updated unit files should they change on a run.